### PR TITLE
Fix preview image discrepancy in RD-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.5
+
+- Fix the MatchImageUi component displaying the wrong image when there is no
+  reference batch.
+- Support two-way on top of three-way image comparisons in the visualizer.
+
 ## v0.6.4
 
 - Fix the MatchImageUi component displaying the wrong image when filtering out

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codec_compare",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Codec performance comparison tool",
   "publisher": "Google LLC",
   "author": "Yannis Guyon",

--- a/src/codec_compare.ts
+++ b/src/codec_compare.ts
@@ -252,7 +252,7 @@ export class CodecCompare extends LitElement {
           </p>
 
           <p id="credits">
-            Codec Compare version 0.6.4<br>
+            Codec Compare version 0.6.5<br>
             <a href="https://github.com/webmproject/codec-compare">
               Sources on GitHub
             </a>

--- a/src/panel_ui.ts
+++ b/src/panel_ui.ts
@@ -72,6 +72,12 @@ export class PanelUi extends LitElement {
       this.style.display = 'block';
       this.requestUpdate();
     });
+    listen(EventType.MATCHED_DATA_POINTS_CHANGED, () => {
+      // The index points to an element of a set that no longer exists.
+      // Invalidate it. This should trickle down till MatchImageUi.
+      this.matchIndex = undefined;
+      this.requestUpdate();
+    });
   }
 
   override render() {
@@ -191,7 +197,7 @@ export class PanelUi extends LitElement {
         </batch-selection-ui>
         <matches-ui .state=${this.state}
           .referenceSelection=${
-        showRowsOnly ? batchSelection : referenceSelection}
+        this.state.rdMode ? undefined : referenceSelection}
           .batchSelection=${batchSelection} .matchIndex=${this.matchIndex}
           style=${activeIndex === BatchTab.MATCHES ? '' : 'display: none'}>
         </matches-ui>

--- a/src/visualizer.ts
+++ b/src/visualizer.ts
@@ -109,6 +109,12 @@ export class ImageVisualizer extends LitElement {
     setImageText(this.leftImage, this.leftText, url, 'limg', 'ltxt');
     this.backgroundImage.src = this.bottomImage.src;
 
+    if (url.get('rimg') === url.get('limg') &&
+        url.get('rtxt') === url.get('ltxt')) {
+      // Only compare one image with the bottom image because left and right are
+      // identical.
+      this.horizontalImageWindow.hidden = true;
+    }
     this.addEventListener('mousemove', this.onMouseMove);
   }
 


### PR DESCRIPTION
Instead of passing around the selected batch as the reference batch when in absolute or RD-mode, leave the reference batch undefined to avoid wrongly referencing into the selected batch with rightIndex.

When there is a reference:
  leftIndex points to selected row (correct)
  rightIndex points to reference row (correct)

Otherwise, before this change:
  leftIndex pointed to selected row (correct)
  rightIndex pointed to selected row (which is wrongly indexed)
Otherwise, after this change:
  leftIndex points to selected row (correct)
  rightIndex cannot point to undefined (caught by typescript)

The data shown in the table was correct. Only some cell coloring and the preview image were sometimes stale.